### PR TITLE
Fix translations of result extra info labels. Read querystringindexes from jotai atom ( we have two stores: Volto and searchkit)

### DIFF
--- a/packages/volto-searchkit-block/news/27.bugfix
+++ b/packages/volto-searchkit-block/news/27.bugfix
@@ -1,0 +1,1 @@
+Fix translations of result extra info labels. Read querystringindexes from jotai atom ( we have two stores: Volto and searchkit). @ksuess

--- a/packages/volto-searchkit-block/src/atoms/QuerystringIndexes.jsx
+++ b/packages/volto-searchkit-block/src/atoms/QuerystringIndexes.jsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useSetAtom } from 'jotai';
+import { getQuerystring } from '@plone/volto/actions/querystring/querystring';
+import { querystringIndexesAtom } from './index';
+
+export const FetchQuerystringIndexes = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getQuerystring());
+  }, [dispatch]);
+
+  return null;
+};
+
+export const InitializeAtom = () => {
+  const setQuerystringIndexes = useSetAtom(querystringIndexesAtom);
+  const indexes = useSelector((state) => state.querystring?.indexes);
+
+  useEffect(() => {
+    if (indexes) {
+      setQuerystringIndexes(indexes);
+    }
+  }, [indexes, setQuerystringIndexes]);
+
+  return null;
+};

--- a/packages/volto-searchkit-block/src/atoms/index.js
+++ b/packages/volto-searchkit-block/src/atoms/index.js
@@ -1,0 +1,4 @@
+// Jotai atom to store querystringindexes from global state
+import { atom } from 'jotai';
+
+export const querystringIndexesAtom = atom({});

--- a/packages/volto-searchkit-block/src/components/Views/ExtraInfo.jsx
+++ b/packages/volto-searchkit-block/src/components/Views/ExtraInfo.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useAtomValue } from 'jotai';
 import { FormattedMessage } from 'react-intl';
 import { Item } from 'semantic-ui-react';
 import { onQueryChanged, withState } from 'react-searchkit';
 import { getObjectFromObjectList, translateQuerystringindex } from '../helpers';
+import { querystringIndexesAtom } from '../../atoms';
 
 const _ExtraInfo = (props) => {
   const { result } = props;
@@ -16,9 +17,7 @@ const _ExtraInfo = (props) => {
   );
   let subjectsFieldname = props.currentQueryState.data?.subjectsFieldname; // "subjects";
 
-  const querystringindexes = useSelector(
-    (state) => state.query?.querystringindexes,
-  );
+  const querystringindexes = useAtomValue(querystringIndexesAtom);
 
   return (
     <Item.Extra className="metadata">
@@ -67,7 +66,11 @@ const _ExtraInfo = (props) => {
           <React.Fragment key={extrainfo_key}>
             <span className="label">{extrainfo_fields[extrainfo_key]}:</span>
             {extrainfo_value?.map((item, index) => {
-              let tito = item.title || item.token || item;
+              let tito = translateQuerystringindex(
+                querystringindexes,
+                extrainfo_key,
+                item,
+              );
               return (
                 <span key={index}>
                   {tito}

--- a/packages/volto-searchkit-block/src/index.js
+++ b/packages/volto-searchkit-block/src/index.js
@@ -12,8 +12,24 @@ import {
 } from './components/Blocks/Reference';
 
 import SearchSectionsWidget from './components/Blocks/SearchSectionsWidget';
+import {
+  FetchQuerystringIndexes,
+  InitializeAtom,
+} from './atoms/QuerystringIndexes';
 
 const applyConfig = (config) => {
+  config.settings.appExtras = [
+    ...config.settings.appExtras,
+    {
+      match: '/',
+      component: FetchQuerystringIndexes,
+    },
+    {
+      match: '/',
+      component: InitializeAtom,
+    },
+  ];
+
   // @eeacms/volto-matomo
   config.settings.searchkitblock = {
     trackVoltoMatomo: false,
@@ -99,32 +115,6 @@ const applyConfig = (config) => {
     // backend_url: 'http://host.docker.internal:8080/Plone',
     // frontend_url: 'http://localhost:3000',
   };
-
-  // Fetch querystring indexes.
-  // See /effective-volto/addons/asyncconnect
-  // config.settings.asyncPropsExtenders = [
-  //   ...(config.settings.asyncPropsExtenders || []),
-  //   {
-  //     path: '/',
-  //     extend: (dispatchActions) => {
-  //       const action = {
-  //         key: 'querystringindexes',
-  //         promise: ({ store }) => {
-  //           const state = store.getState();
-  //           if (state.querystring?.indexes?.Title) {
-  //             return;
-  //           }
-  //           const myaction = getQuerystring();
-  //           return store.dispatch(myaction).catch((e) => {
-  //             // eslint-disable-next-line no-console
-  //             console.error('Fetch of getQuerystring failed');
-  //           });
-  //         },
-  //       };
-  //       return [...dispatchActions, action];
-  //     },
-  //   },
-  // ];
 
   return config;
 };


### PR DESCRIPTION
<img width="679" height="673" alt="Screenshot 2026-07-10 at 15 46 26" src="https://github.com/user-attachments/assets/a5de18a4-a57f-4acf-b61b-bdc32c923b9e" />
